### PR TITLE
refactor[workflow]: remove files functionality completely from release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     # Use @latest for newest version, or pin to specific version like @v1.0.0
     uses: rocajuanma/simple-release/workflows/reusable-release.yml@latest
     with:
-      release-files: ''  # Optional: Additional files to include
+      changelog-path: 'CHANGELOG.md'  # Optional: Changelog path
     secrets:
       RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -63,7 +63,7 @@ Create `CHANGELOG.md`:
 ## Usage
 
 1. **Push a tag**: `git tag v1.0.0 && git push origin v1.0.0`
-2. **Release created** with changelog content
+2. **Release created** with changelog content (no files attached)
 3. **Changelog updated** automatically
 4. **PR created** with changelog changes
 

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -14,6 +14,5 @@ jobs:
     uses: rocajuanma/simple-release/workflows/reusable-release.yml@latest
     with:
       changelog-path: 'CHANGELOG.md'        # Optional: Changelog path (default: CHANGELOG.md)
-      release-files: ''                     # Optional: Additional files to include (empty for no files)
     secrets:
       RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/reusable-release.yml
+++ b/workflows/reusable-release.yml
@@ -22,11 +22,6 @@ on:
         description: 'Custom build command (overrides default Go build)'
         required: false
         type: string
-      release-files:
-        description: 'Additional files to include in release'
-        required: false
-        type: string
-        default: ''
     secrets:
       RELEASE_TOKEN:
         description: 'GitHub token for creating releases'
@@ -121,7 +116,6 @@ jobs:
         tag_name: ${{ steps.version.outputs.VERSION }}
         name: ${{ steps.version.outputs.VERSION }}
         body: ${{ steps.release_notes.outputs.RELEASE_NOTES }}
-        files: ${{ inputs.release-files }}
         draft: false
         prerelease: false
       env:


### PR DESCRIPTION
- Remove release-files parameter from workflow inputs
- Simplify release creation to single step without files
- Update examples to remove file references
- Update documentation to reflect changelog-only releases
- Focus on template repository usage without file attachments