### PR TITLE
fix: add permissions to post-release workflow

### DIFF
--- a/.github/workflows/post-release-changelog.yml
+++ b/.github/workflows/post-release-changelog.yml
@@ -8,6 +8,9 @@ jobs:
   update-changelog:
     name: Update Changelog After Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Add contents: write and pull-requests: write permissions
- Ensures post-release workflow can create PRs and update files
- Fixes issue where post-release workflow doesn't trigger after releases