### PR TITLE
fix: implement repository dispatch for post-release workflow

### DIFF
--- a/.github/workflows/post-release-changelog.yml
+++ b/.github/workflows/post-release-changelog.yml
@@ -1,8 +1,8 @@
 name: Post-Release Changelog Update
 
 on:
-  release:
-    types: [published]  # Triggers after a release is successfully published
+  repository_dispatch:
+    types: [release-published]
 
 jobs:
   update-changelog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,3 +120,10 @@ jobs:
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Trigger post-release workflow
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        event-type: release-published
+        client-payload: '{"version": "${{ steps.version.outputs.VERSION }}"}'


### PR DESCRIPTION
- Add repository dispatch trigger to release workflow after successful release
- Change post-release workflow to listen for repository_dispatch events
- Ensures post-release runs only after release is published
- Eliminates race conditions and timing issues with release events
- Passes version information to post-release workflow